### PR TITLE
removing some styles that hid the left nav toggle when sync status indicated

### DIFF
--- a/core.css
+++ b/core.css
@@ -943,15 +943,7 @@ padding:  var(--s1);
     z-index: 99999;
 }
 
-/* TOP RIGHT TOOLBAR ICONS */
-
-.rm-topbar > * {
-    position: absolute;
-}
-
-#app > div > div > div.flex-h-box > div.roam-main > div.rm-files-dropzone > div > span:nth-child(7) > span > span > span
-{padding-top: 25px}
-  
+/* TOP RIGHT TOOLBAR ICONS */  
 .rm-topbar > .bp3-popover-wrapper {
     width: 490px; /* CRL EDIT */
     flex-direction: column; /* CRL EDIT */


### PR DESCRIPTION
Should solve [this issue](https://github.com/calrobertlee/roam-css-styles/issues/29). I did some testing to see if removing them broke anything but didn't come across any additional styling bugs.

**Before**
![image](https://user-images.githubusercontent.com/5056251/118412880-461f6180-b651-11eb-8b78-5d7b7808f2ce.png)

**After**
![image](https://user-images.githubusercontent.com/5056251/118412911-6bac6b00-b651-11eb-9f69-205e9e1b135f.png)
